### PR TITLE
Experimental: `smartContent` for some feed items.

### DIFF
--- a/Feeds/Account.h
+++ b/Feeds/Account.h
@@ -80,6 +80,8 @@ typedef enum {
 // for subclassers
 @property (nonatomic, strong) SMWebRequest *request, *tokenRequest;
 
+- (NSString *)smartContentForItem:(FeedItem *)item;
+
 @end
 
 // informal protocol that Account subclasses can implement if they want to take the responsibility of parsing

--- a/Feeds/Account.m
+++ b/Feeds/Account.m
@@ -278,6 +278,11 @@ static NSMutableArray *registeredClasses = nil;
         SecKeychainItemDelete(itemRef);
 }
 
+- (NSString *)smartContentForItem:(FeedItem *)item {
+    [self doesNotRecognizeSelector:@selector(smartContentForItem:)];
+    return nil;
+}
+
 #pragma mark NSTableViewDataSource, exposes Feeds
 
 - (NSInteger)numberOfRowsInTableView:(NSTableView *)tableView {

--- a/Feeds/AppDelegate.m
+++ b/Feeds/AppDelegate.m
@@ -460,10 +460,10 @@ const int ddLogLevel = LOG_LEVEL_INFO;
         NSString *cssPath = [[NSBundle mainBundle] pathForResource:@"Popover" ofType:@"css"];
         css = [NSString stringWithContentsOfFile:cssPath encoding:NSUTF8StringEncoding error:NULL];
     }
-    
+   
     NSString *templatePath = [[NSBundle mainBundle] pathForResource:@"Popover" ofType:@"html"];
     NSString *template = [NSString stringWithContentsOfFile:templatePath encoding:NSUTF8StringEncoding error:NULL];
-    NSString *rendered = [NSString stringWithFormat:template, css, NSStringFromClass(item.feed.account.class), [titleOrFallback truncatedAfterIndex:75], authorAndTime, item.content ?: @""];
+    NSString *rendered = [NSString stringWithFormat:template, css, NSStringFromClass(item.feed.account.class), [titleOrFallback truncatedAfterIndex:75], authorAndTime, item.smartContent ?: @""];
 
     //NSLog(@"Rendered:\n%@\n", rendered);
     

--- a/Feeds/Feed.h
+++ b/Feeds/Feed.h
@@ -33,6 +33,7 @@ NSDate *AutoFormatDate(NSString *dateString);
 @interface FeedItem : NSObject
 
 @property (nonatomic, copy) NSString *identifier, *title, *author, *authorIdentifier, *project, *content, *rawDate;
+@property (nonatomic, copy, readonly) NSString *smartContent;
 @property (nonatomic, strong) NSURL *link, *comments;
 @property (nonatomic, strong) NSDate *published, *updated;
 @property (nonatomic, assign) BOOL notified, viewed, authoredByMe;

--- a/Feeds/Feed.m
+++ b/Feeds/Feed.m
@@ -479,4 +479,12 @@ NSDate *AutoFormatDate(NSString *dateString) {
     }
 }
 
+- (NSString *)smartContent {
+    if ([self.feed.account respondsToSelector:@selector(smartContentForItem:)]) {
+        NSString *smartContent = [self.feed.account smartContentForItem:self];
+        return smartContent;
+    }
+    return self.content;
+}
+
 @end


### PR DESCRIPTION
Ask the feed account for an enhanced version of the item's content.

For instance, in github I'd like to see the repository description for
some kind of activities without opening the item in the browser.
Github should include it on the feed but it doesn't.

The implementation is a proof-of-concept (aka quick hack). 
It makes synchronous requests to github api (they are fast, but I guess it can lock the app in old machines or on a poor network).
